### PR TITLE
Segfaultremoval

### DIFF
--- a/bin/local.js
+++ b/bin/local.js
@@ -11,17 +11,12 @@ var fs = require('fs'),
     util = require('../lib/util'),
     WebSocketClient = require('../lib/ws-client'),
     bigSync = require('../lib/big-sync'),
-    SegfaultHandler = require('segfault-handler'),
     config = util.getConfig(),
     ignored = config.excludes,
     isPaused = false,
     devbox = null;
 
 require('colors');
-
-if (config.debug) {
-    SegfaultHandler.registerHandler();
-}
 
 var NUM_FILES_FOR_LARGE_SEND = 10;
 var FILE_CHANGE_COOLDOWN_TIME = 10;
@@ -44,9 +39,9 @@ function onBigTransferDone() {
 
 function filterAndRebounce(evt, filepath) {
     var relativePath = filepath.replace(config.sourceLocation, '');
-    
+
     if (util.isExcluded(relativePath, ignored) || isPaused) return false;
-    
+
     rebouncedFileChange(evt, filepath);
 }
 
@@ -76,6 +71,7 @@ function startFileWatch() {
     watcher.watch(config.sourceLocation, {
         ignored: ignored,
         persistent: true,
+        followSymlinks: false,
         ignoreInitial: true
     }).on('all', filterAndRebounce);
 }

--- a/bin/remote.js
+++ b/bin/remote.js
@@ -8,25 +8,19 @@
  *  you shouldn't need this file at all
  */
 var fs = require('fs-extra'),
-    sys = require('sys'),
     Server = require('../lib/ws-server'),
     util = require('../lib/util'),
-    SegfaultHandler = require('segfault-handler'),
     config = util.getConfig(),
     destinationLocation = config.destinationLocation,
     server = new Server({
         port: config.websocketPort
     });
 
-if (config.debug) {
-    SegfaultHandler.registerHandler();
-}
-
 require('colors');
 
 function serverLog(message) {
     var prefix = '[' + config.hostname + '] ';
-    sys.puts(prefix + message);
+    console.log(prefix + message);
 }
 
 function addFile(message) {

--- a/lib/big-sync.js
+++ b/lib/big-sync.js
@@ -1,10 +1,11 @@
 var Rsync = require('rsync'),
+    _ = require('lodash'),
     util = require('../lib/util'),
     config = util.getConfig();
 
 module.exports = function bigSync(onComplete) {
 
-    if (util.isEmpty(config)) {
+    if (_.isEmpty(config)) {
         return console.log('Please run `sicksync --setup` before doing a one-time sync');
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,11 +24,6 @@ module.exports = {
         return (fs.existsSync(configPath)) ? require(configPath) : {};
     },
 
-    // Returns a boolean if the object is empty
-    isEmpty: function(obj) {
-        return Object.keys(obj).length === 0;
-    },
-
     // Randomly generate a unique ID
     getId: function() {
         return Math.random().toString(36).substr(2, 9) + Date.now();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sicksync-remote": "./bin/remote.js"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^2.2.0",
     "istanbul": "^0.3.2",
     "segfault-handler": "^0.2.4",
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "istanbul": "^0.3.2",
-    "segfault-handler": "^0.2.4",
     "mocha": "^2.0.1",
     "rewire": "^2.1.0",
     "sinon": "^1.12.1"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "colors": "^1.0.3",
     "commander": "^2.5.0",
     "fs-extra": "^0.18.2",
+    "lodash": "^3.7.0",
     "merge": "^1.2.0",
     "minimatch": "^2.0.1",
     "prompt": "^0.2.14",
@@ -40,7 +41,7 @@
     "sicksync-remote": "./bin/remote.js"
   },
   "devDependencies": {
-    "chai": "^2.2.0",
+    "chai": "^1.10.0",
     "istanbul": "^0.3.2",
     "segfault-handler": "^0.2.4",
     "mocha": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,15 +24,14 @@
   "author": "jgriffith",
   "license": "Apache-2.0",
   "dependencies": {
-    "chokidar": "^0.12.1",
+    "chokidar": "^1.0.1",
     "colors": "^1.0.3",
     "commander": "^2.5.0",
-    "fs-extra": "^0.16.3",
+    "fs-extra": "^0.18.2",
     "merge": "^1.2.0",
     "minimatch": "^2.0.1",
     "prompt": "^0.2.14",
     "rsync": "^0.4.0",
-    "segfault-handler": "^0.2.4",
     "ws": "^0.7.1"
   },
   "bin": {
@@ -41,8 +40,9 @@
     "sicksync-remote": "./bin/remote.js"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^2.2.0",
     "istanbul": "^0.3.2",
+    "segfault-handler": "^0.2.4",
     "mocha": "^2.0.1",
     "rewire": "^2.1.0",
     "sinon": "^1.12.1"

--- a/test/big-sync.mspec.js
+++ b/test/big-sync.mspec.js
@@ -1,8 +1,7 @@
 var expect = require('chai').expect,
     rewire = require('rewire'),
     sinon = require('sinon'),
-    bigSync = rewire('../lib/big-sync'),
-    testUtils = require('./utils');
+    bigSync = rewire('../lib/big-sync');
 
 var mockConfig = {
     excludes: ['one', 'two', 'three'],
@@ -26,7 +25,7 @@ var rsyncSpies = (function() {
         BuildSpies.prototype.exclude.reset();
         BuildSpies.prototype.source.reset();
         BuildSpies.prototype.destination.reset();
-    }
+    };
 
     return new BuildSpies();
 })();
@@ -58,7 +57,6 @@ describe('bigSync', function() {
 
         it('should log a message to run `sicksync --setup`', function() {
             bigSync();
-            expect(consoleSpy.log.called).to.be.true();
             expect(consoleSpy.log.getCall(0).args[0]).to.contain('--setup');
         });
     });

--- a/test/util.mspec.js
+++ b/test/util.mspec.js
@@ -55,7 +55,7 @@ describe('util', function() {
         });
 
         it('should contain `json` in it\'s path', function() {
-            expect(util.getConfigPath().indexOf('json') > -1).to.be.true();
+            expect(util.getConfigPath().indexOf('json') > -1).to.be.true;
         });
     });
 
@@ -74,18 +74,6 @@ describe('util', function() {
             util.__set__('fs', { existsSync: function() { return false; } });
 
             expect(util.getConfig()).to.deep.equal({});
-        });
-    });
-
-    describe('#isEmpty', function() {
-        it('should return true if it\'s passed an empty object', function() {
-            expect(util.isEmpty({})).to.be.true();
-        });
-
-        it('should return false if it\'s passed a non-empty object', function() {
-            expect(util.isEmpty({
-                'wat': 'wat'
-            })).to.be.false();
         });
     });
 
@@ -121,7 +109,7 @@ describe('util', function() {
                 some: 'object',
                 syncsRemotely: false
             });
-            expect(outputFileSyncSpy.called).to.be.true();
+            expect(outputFileSyncSpy.called).to.be.true;
         });
 
         it('should call `fs.outputFileSyncSpy` with the right arguments', function() {
@@ -144,7 +132,7 @@ describe('util', function() {
                 some: 'object',
                 syncsRemotely: true
             });
-            expect(util.writeConfigToDev.called).to.be.true();
+            expect(util.writeConfigToDev.called).to.be.true;
         });
     });
 
@@ -163,7 +151,7 @@ describe('util', function() {
 
         it('should call `exec`', function() {
             util.writeConfigToDev({});
-            expect(execSpy.called).to.be.true();
+            expect(execSpy.called).to.be.true;
         });
 
         it('should call `exec` with the appropriate parameters', function() {

--- a/test/util.mspec.js
+++ b/test/util.mspec.js
@@ -175,7 +175,7 @@ describe('util', function() {
                 util.writeConfigToDev({});
                 execSpy.getCall(0).args[1](null);
 
-                expect(console.log.called).to.be.true();
+                expect(console.log.called).to.be.true;
                 console.log.restore();
             });
 
@@ -195,7 +195,7 @@ describe('util', function() {
                 'some/file/path'
             ];
 
-            expect(util.isExcluded(fileToExclude, pathsToExclude)).to.be.true();
+            expect(util.isExcluded(fileToExclude, pathsToExclude)).to.be.true;
         });
 
         it('should return true if the filepath contains text in the excluded array', function() {
@@ -204,7 +204,7 @@ describe('util', function() {
                 'some/**'
             ];
 
-            expect(util.isExcluded(fileToExclude, pathsToExclude)).to.be.true();
+            expect(util.isExcluded(fileToExclude, pathsToExclude)).to.be.true;
         });
 
         it('should return false if the filepath isn\'t excluded', function() {
@@ -213,7 +213,7 @@ describe('util', function() {
                 'another/file/path'
             ];
 
-            expect(util.isExcluded(fileToExclude, pathsToExclude)).to.be.false();
+            expect(util.isExcluded(fileToExclude, pathsToExclude)).to.be.false;
         });
     });
 
@@ -241,7 +241,7 @@ describe('util', function() {
             });
 
             it('should call `desiredFn` the amount of times it was invoked', function() {
-                expect(desiredFn.calledThrice).to.be.true();
+                expect(desiredFn.calledThrice).to.be.true;
             });
 
             it('should called the `desiredFn` with the right arguments', function() {
@@ -270,32 +270,32 @@ describe('util', function() {
             });
 
             it('should not call `desiredFn`', function() {
-                expect(desiredFn.called).to.be.false();
+                expect(desiredFn.called).to.be.false;
             });
 
             it('should call the `fallbackFn', function() {
-                expect(fallbackFn.called).to.be.true();
+                expect(fallbackFn.called).to.be.true;
             });
 
             it('should not call `fallbackFn` more than once', function() {
-                expect(fallbackFn.calledTwice).to.be.false();
+                expect(fallbackFn.calledTwice).to.be.false;
             });
 
             it('should not call `desiredFn` after `fallbackFn` is called', function() {
                 rebouncedFn();
-                expect(desiredFn.called).to.be.false();
+                expect(desiredFn.called).to.be.false;
             });
 
             it('should not call `fallbackFn` after another call to the rebounced function', function() {
                 rebouncedFn();
                 expect(rebouncedFn()).to.be.a('undefined');
-                expect(fallbackFn.calledTwice).to.be.false();
+                expect(fallbackFn.calledTwice).to.be.false;
             });
 
             it('should call the `desiredFn` again after the cool-down is complete', function(done) {
                 function afterCoolDown() {
                     setTimeout(function() {
-                        expect(desiredFn.called).to.be.true();
+                        expect(desiredFn.called).to.be.true;
                         done();
                     }, 11);
                 }
@@ -321,7 +321,7 @@ describe('util', function() {
             });
 
             it('should call `desiredFn` the number of times it was invoked', function() {
-                expect(desiredFn.calledThrice).to.be.true();
+                expect(desiredFn.calledThrice).to.be.true;
             });
         });
     });
@@ -351,7 +351,7 @@ describe('util', function() {
 
         it('should call `exec`', function() {
             util.open('somefile');
-            expect(execSpy.called).to.be.true();
+            expect(execSpy.called).to.be.true;
         });
 
         it('should pass in parameters to the `exec` call', function() {
@@ -363,32 +363,32 @@ describe('util', function() {
 
     describe('#toBoolean', function() {
         it('should convert `yes` to `true`', function() {
-            expect(util.toBoolean('yes')).to.be.true();
+            expect(util.toBoolean('yes')).to.be.true;
         });
 
         it('should convert `y` to `true`', function() {
-            expect(util.toBoolean('y')).to.be.true();
+            expect(util.toBoolean('y')).to.be.true;
         });
 
         it('should conver the string `true` to `true`', function() {
-            expect(util.toBoolean('true')).to.be.true();
+            expect(util.toBoolean('true')).to.be.true;
         });
 
         it('should convert `no` to `false`', function() {
-            expect(util.toBoolean('no')).to.be.false();
+            expect(util.toBoolean('no')).to.be.false;
         });
 
         it('should convert `n` to `false`', function() {
-            expect(util.toBoolean('n')).to.be.false();
+            expect(util.toBoolean('n')).to.be.false;
         });
 
         it('should conver the string `false` to `false`', function() {
-            expect(util.toBoolean('false')).to.be.false();
+            expect(util.toBoolean('false')).to.be.false;
         });
 
         it('should return false for all other strings', function() {
-            expect(util.toBoolean('')).to.be.false();
-            expect(util.toBoolean('possible')).to.be.false();
+            expect(util.toBoolean('')).to.be.false;
+            expect(util.toBoolean('possible')).to.be.false;
         });
     });
 
@@ -425,7 +425,7 @@ describe('util', function() {
             });
 
             it('should fork the process', function() {
-                expect(forkSpy.called).to.be.true();
+                expect(forkSpy.called).to.be.true;
             });
 
             it('should pass in the location of the start-script', function() {
@@ -463,7 +463,7 @@ describe('util', function() {
         });
 
         it('should call the `start` method', function() {
-            expect(promptMock.start.called).to.be.true();
+            expect(promptMock.start.called).to.be.true;
         });
     });
 });

--- a/test/ws-client.mspec.js
+++ b/test/ws-client.mspec.js
@@ -53,7 +53,7 @@ describe('ws-client', function() {
         });
 
         it('should register callbacks via the `on` method', function() {
-            expect(wsMock.on.called).to.be.true();
+            expect(wsMock.on.called).to.be.true;
         });
 
         it('should register a callback for the `open` message', function() {
@@ -90,7 +90,7 @@ describe('ws-client', function() {
         });
 
         it('should send a message to the web-socket', function() {
-            expect(wsMock.send.called).to.be.true();
+            expect(wsMock.send.called).to.be.true;
         });
 
         it('should send a `subject` and `token` property in the payload', function() {
@@ -129,7 +129,7 @@ describe('ws-client', function() {
             triggerMessage({isAllowed: false});
 
             setTimeout(function() {
-                expect(authorizedSpy.called).to.be.false();
+                expect(authorizedSpy.called).to.be.false;
                 done();
             }, 10);
         });
@@ -170,12 +170,12 @@ describe('ws-client', function() {
         });
 
         it('should get the remote machine back up to date with a `bigSync` call', function() {
-            expect(bigSyncMock.called).to.be.true();
+            expect(bigSyncMock.called).to.be.true;
         });
 
         it('should attempt to awaken the devbox after the `bigSync` call', function() {
             bigSyncMock.getCall(0).args[0](); // Execute the bigSync callback function
-            expect(utilMock.wakeDevBox.called).to.be.true();
+            expect(utilMock.wakeDevBox.called).to.be.true;
         });
 
         it('when the `retryOnDisconnect` flag is set to `false` should exit the process', function() {
@@ -191,7 +191,7 @@ describe('ws-client', function() {
 
             // Trigger `close`
             wsMock.on.getCall(2).args[1]();
-            expect(processMock.exit.called).to.be.true();
+            expect(processMock.exit.called).to.be.true;
         });
     });
 
@@ -226,7 +226,7 @@ describe('ws-client', function() {
         });
 
         it('should trigger a `bigSync` to bring remote up to date', function() {
-            expect(bigSyncMock.called).to.be.true();
+            expect(bigSyncMock.called).to.be.true;
         });
 
         it('should log the problem, and try to wake the dev box after a `bigSync`', function() {
@@ -236,7 +236,7 @@ describe('ws-client', function() {
 
         it('should call util#wakeDevBox', function() {
             bigSyncMock.getCall(0).args[0](); // Execute the bigSync callback function
-            expect(utilMock.wakeDevBox.called).to.be.true();
+            expect(utilMock.wakeDevBox.called).to.be.true;
         });
 
         it('should pass in the hostname and callback function into the #wakeDevBox call', function() {

--- a/test/ws-server.mspec.js
+++ b/test/ws-server.mspec.js
@@ -68,7 +68,7 @@ describe('ws-server', function() {
         });
 
         it('should log that the server is up', function() {
-            expect(consoleMock.called).to.be.true();
+            expect(consoleMock.called).to.be.true;
         });
 
         describe('when a client connects', function() {
@@ -104,7 +104,7 @@ describe('ws-server', function() {
                 });
 
                 it('should kill the process', function() {
-                    expect(processSpy.exit.called).to.be.true();
+                    expect(processSpy.exit.called).to.be.true;
                 });
 
                 it('should log the message', function() {
@@ -123,7 +123,7 @@ describe('ws-server', function() {
                 });
 
                 it('should kill the process', function() {
-                    expect(processSpy.exit.called).to.be.true();
+                    expect(processSpy.exit.called).to.be.true;
                 });
 
                 it('should log the message', function() {
@@ -143,7 +143,7 @@ describe('ws-server', function() {
                 });
 
                 it('should close the connection', function() {
-                    expect(_wsMock.close.called).to.be.true();
+                    expect(_wsMock.close.called).to.be.true;
                 });
             });
 
@@ -159,7 +159,7 @@ describe('ws-server', function() {
                 });
 
                 it('should send a response back', function() {
-                    expect(_wsMock.send.called).to.be.true();
+                    expect(_wsMock.send.called).to.be.true;
                 });
 
                 it('should contain a `subject` of `handshake`', function() {
@@ -169,7 +169,7 @@ describe('ws-server', function() {
 
                 it('should contain an `isAllowed` parameter of `true`', function() {
                     var handshakeRes = _wsMock.send.getCall(0).args;
-                    expect(JSON.parse(handshakeRes).isAllowed).to.be.true();
+                    expect(JSON.parse(handshakeRes).isAllowed).to.be.true;
                 });
             });
 


### PR DESCRIPTION
Overview:

- Segfault handler hoses the application from building in Node >0.12, so it's removed for now (we can revisit implementing this in development builds).
- `util.puts` or `sys.puts` is deprecated in Node > 0.12, and is replaced in favor of `console.log`
- Chai v2.x removes support for `true()` and `false()`, so they are replaced with just the `.true` and `.false` assertions.