### PR TITLE
Prevent duplicate listeners on the file watcher

### DIFF
--- a/bin/local.js
+++ b/bin/local.js
@@ -14,7 +14,8 @@ var fs = require('fs'),
     config = util.getConfig(),
     ignored = config.excludes,
     isPaused = false,
-    devbox = null;
+    devbox = null,
+    fswatcher = null;
 
 require('colors');
 
@@ -68,7 +69,10 @@ function onFileChange(evt, filepath) {
 }
 
 function startFileWatch() {
-    watcher.watch(config.sourceLocation, {
+    if (fswatcher){
+        fswatcher.close();
+    }
+    fswatcher = watcher.watch(config.sourceLocation, {
         ignored: ignored,
         persistent: true,
         followSymlinks: false,


### PR DESCRIPTION
startFileWatch() is called every time a connection is lost and then re-established.  Each time it was adding another set of listeners and then pushing the same files multiple times.