### PR TITLE
Feature/rsync with progress and delete

### DIFF
--- a/lib/big-sync.js
+++ b/lib/big-sync.js
@@ -14,7 +14,10 @@ module.exports = function bigSync(onComplete) {
         .flags('az')
         .exclude(config.excludes)
         .source(config.sourceLocation)
+        .set('delete')
         .destination(config.hostname + ':' + config.destinationLocation);
+
+    if (config.debug) rsync.set('progress');
 
     rsync.execute(onComplete);
 };

--- a/lib/big-sync.js
+++ b/lib/big-sync.js
@@ -3,6 +3,10 @@ var Rsync = require('rsync'),
     util = require('../lib/util'),
     config = util.getConfig();
 
+function consoleLogFromBuffer(buffer) {
+    console.log(buffer.toString());
+}
+
 module.exports = function bigSync(onComplete) {
 
     if (_.isEmpty(config)) {
@@ -17,7 +21,9 @@ module.exports = function bigSync(onComplete) {
         .set('delete')
         .destination(config.hostname + ':' + config.destinationLocation);
 
-    if (config.debug) rsync.set('progress');
-
+    if (config.debug) {
+        rsync.set('progress');
+        rsync.output(consoleLogFromBuffer, consoleLogFromBuffer);
+    }
     rsync.execute(onComplete);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sicksync",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Don’t accept the available as the preferable. Go extra mile with extra speed.",
   "main": "index.js",
   "scripts": {

--- a/test/big-sync.mspec.js
+++ b/test/big-sync.mspec.js
@@ -18,6 +18,7 @@ var rsyncSpies = (function() {
     BuildSpies.prototype.exclude = sinon.stub().returns(BuildSpies.prototype);
     BuildSpies.prototype.source = sinon.stub().returns(BuildSpies.prototype);
     BuildSpies.prototype.destination = sinon.stub().returns(BuildSpies.prototype);
+    BuildSpies.prototype.set = sinon.stub().returns(BuildSpies.prototype);
     BuildSpies.prototype.execute = function(cb) { cb(); };
     BuildSpies.prototype.resetAll = function() {
         BuildSpies.prototype.shell.reset();
@@ -25,6 +26,7 @@ var rsyncSpies = (function() {
         BuildSpies.prototype.exclude.reset();
         BuildSpies.prototype.source.reset();
         BuildSpies.prototype.destination.reset();
+        BuildSpies.prototype.set.reset();
     };
 
     return new BuildSpies();
@@ -92,6 +94,32 @@ describe('bigSync', function() {
         it('should set the `destination` property to match the on one in the config', function() {
             var destination = mockConfig.hostname + ':' + mockConfig.destinationLocation;
             expect(destination).to.equal(rsyncSpies.destination.getCall(0).args[0]);
+        });
+
+        it('should set the deletion flag', function() {
+            expect('delete').to.equal(rsyncSpies.set.getCall(0).args[0]);
+        });
+    });
+
+    describe('when `debug` is true', function () {
+        function runBigSyncWithConfig(config) {
+            bigSync.__set__('Rsync', RsyncMockConstructor);
+            bigSync.__set__('config', config);
+            bigSync(function() {});
+        }
+
+        it('should set the `progress` flag', function() {
+            var config = {
+                excludes: ['one', 'two', 'three'],
+                sourceLocation: '/some/file/path',
+                hostname: 'myCoolHost',
+                destinationLocation: '/some/where/out/there',
+                debug: true
+            };
+
+            runBigSyncWithConfig(config);
+
+            expect('progress').to.equal(rsyncSpies.set.getCall(1).args[0]);
         });
     });
 });


### PR DESCRIPTION
Version bump to `1.2.0` since there are some new behaviors (mainly that `big-sync` now logs messages when the config `debug` is `true`).

`big-sync` now sends deletions as well, which it didn't before. Be warned!

Fixes: https://github.com/appnexus/sicksync/issues/32