### PR TITLE
Better Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ sicksync is a CLI to sync your projects code to a remote machine. If you work in
 - NodeJS with npm
 - You can `npm install -g` without `sudo`
 - You can just `ssh to-your-remote-machine` without using a password (ie, ssh keys)
+- On Windows you should have [Cygwin]/[MinGW]/[Babun] installed, with `cygpath`, `ssh`, and `rsync` modules.
+
+[Cygwin]: https://cygwin.com
+[MinGW]: http://www.mingw.org
+[Babun]: http://babun.github.io
 
 ## Install
 Installing `sicksync` is easy, and can easily be added your existing machines after they've been added:

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Don’t accept the available as the preferable. Go extra mile with extra speed.",
   "main": "src/index.js",
   "scripts": {
-    "preinstall": "./scripts/pre-install.js",
+    "preinstall": "node ./scripts/pre-install.js",
     "test": "istanbul cover _mocha -- test/*.mspec.js test/**/*.mspec.js --compilers js:babel/register",
     "watch": "npm run transpile -- -w",
     "transpile": "babel src --out-dir dist",
     "tdd": "mocha --check-leaks test/*.mspec.js test/**/*.mspec.js --compilers js:babel/register --reporter min -w",
-    "prepublish": "rm -rf ./dist && babel src --out-dir dist"
+    "prepublish": "rimraf ./dist && babel src --out-dir dist"
   },
   "keywords": [
     "sicksync",
@@ -41,6 +41,7 @@
     "lodash": "^3.10.1",
     "minimatch": "^3.0.0",
     "prompt": "^0.2.14",
+    "rimraf": "^2.5.4",
     "rsync": "^0.4.0",
     "untildify": "^2.1.0",
     "ws": "^0.8.0"

--- a/src/big-sync.js
+++ b/src/big-sync.js
@@ -1,10 +1,11 @@
 import Rsync from 'rsync';
 import _ from 'lodash';
-import { hostname } from 'os';
+import os from 'os';
+import { execSync } from 'child_process';
 import { generateLog, ensureTrailingSlash } from './util';
 
 function bigSync(project) {
-    let log = generateLog(project.project, hostname());
+    let log = generateLog(project.project, os.hostname());
 
     function consoleLogFromBuffer(buffer) {
         log(buffer.toString());
@@ -17,6 +18,10 @@ function bigSync(project) {
     let onComplete = _.isFunction(_.last(arguments)) ?
         _.last(arguments) :
         _.noop;
+
+    if (os.platform() === 'win32') {
+        project.sourceLocation = execSync('cygpath ' + project.sourceLocation).toString();
+    }
 
     let rsync = new Rsync()
         .shell('ssh')

--- a/src/local/fs-helper.js
+++ b/src/local/fs-helper.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import fs from 'fs';
+import os from 'os';
 import { watch } from 'chokidar';
 import { EventEmitter } from 'events';
 import path from 'path';
@@ -36,6 +37,10 @@ class FSHelper extends EventEmitter {
     }
 
     onFileChange (evt, sourcepath) {
+        if (os.platform() === 'win32') {
+            sourcepath = sourcepath.replace(/\\/g, '/');
+        }
+
         let relativepath = sourcepath.split(this._baseDir)[1],
             localpath = this._sourceLocation + relativepath,
             fileContents = null;


### PR DESCRIPTION
Fixes #42
    
Use `rimraf` instead of `rm -rf`

When using on Windows it is expected that the user has added Cygwin's path to `%PATH%`

    SET PATH=C:\cygwin\bin;%PATH%

Use `cygpath` to convert `sourceLocation` to proper cygwin path.

Converts Windows paths from "C:\\some\\path" to "C:/some/path"
