### PR TITLE
Fix file watcher excludes issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The location on your remote machine you wish to apply changes to.
 
 `excludes: {array of relative filepaths or globs}`
 
-An array of file(s) or filepath(s) that, when matched, sicksync will ignore and not send changes. Editor configuration and `.git/*` files are generally ok to ignore. Uses [`minimatch`](https://github.com/isaacs/minimatch) for globbing.
+An array of file(s) or filepath(s) that, when matched, sicksync will ignore and not send changes. Editor configuration and `.git/*` files are generally ok to ignore. Uses [`anymatch`](https://github.com/es128/anymatch) for globbing.
 
 `websocketPort: {number}`
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "author": "jgriffith",
   "license": "Apache-2.0",
   "dependencies": {
+    "anymatch": "^1.3.0",
     "chalk": "^1.1.1",
     "chokidar": "^1.0.5",
     "commander": "^2.8.1",
@@ -39,7 +40,6 @@
     "fs-extra": "^0.26.0",
     "latest-version": "^2.0.0",
     "lodash": "^3.10.1",
-    "minimatch": "^3.0.0",
     "parse-gitignore": "^0.3.1",
     "prompt": "^0.2.14",
     "rimraf": "^2.5.4",

--- a/src/local/fs-helper.js
+++ b/src/local/fs-helper.js
@@ -15,14 +15,15 @@ class FSHelper extends EventEmitter {
     constructor(params) {
         super();
 
-        this._sourceLocation = params.sourceLocation;
+        this._sourceLocation = untildify(params.sourceLocation);
         this._excludes = params.excludes || [];
         this._followSymLinks = params.followSymlinks || false;
         this._baseDir = path.parse(this._sourceLocation).base + '/';
         this._paused = true;
 
         // Node/watcher only work with full file-paths (no ~'s)
-        this._watcher = watch(untildify(this._sourceLocation), {
+        this._watcher = watch(this._sourceLocation, {
+                cwd: this._sourceLocation,
                 ignored: this._excludes,
                 persistent: true,
                 followSymlinks: this._followSymlinks,
@@ -41,7 +42,7 @@ class FSHelper extends EventEmitter {
             sourcepath = sourcepath.replace(/\\/g, '/');
         }
 
-        let relativepath = sourcepath.split(this._baseDir)[1],
+        let relativepath = sourcepath,
             localpath = this._sourceLocation + relativepath,
             fileContents = null;
 

--- a/src/project-helper.js
+++ b/src/project-helper.js
@@ -48,10 +48,8 @@ export default {
             },
             excludes: {
                 description: 'Are there any files you\'d like to exclude? Use a comma separated list (supports globbing)',
-                default: '.git/**,.git/**/*,.idea/*,**/*.swp,**/*.svn',
-                before: function(csv) {
-                    return csv.split(',');
-                }
+                default: '.git,.idea,*.swp,*.svn',
+                before: csv => csv.split(','),
             },
             excludesFile: {
                 description: 'Would you like to load excludes from file?',

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import fs from 'fs-extra';
 import {exec, spawn} from 'child_process';
-import minimatch from 'minimatch';
+import anymatch from 'anymatch';
 import chalk from 'chalk';
 import path from 'path';
 import untildify from 'untildify';
@@ -55,7 +55,7 @@ function isExcluded(filepath, excludes) {
     let result = false;
 
     excludes.forEach(function(exclude) {
-        if (minimatch(filepath, exclude)) result = true;
+        if (anymatch(filepath, exclude)) result = true;
     });
 
     return result;


### PR DESCRIPTION
Fix file watcher excludes issue (#47)

Prior to this the File watcher (chokidar) wasn't actually ignoring the excludes. It is required to have `cwd` option passed in for it to work. (small discussion on the [issue here](https://github.com/paulmillr/chokidar/pull/539))

Also use `anymatch` instead of `minimatch`. It better handles matching both globbed and non-globbed paths. 

With these changes we can now simply have exclude patterns like `.git`, or `node_modules` (instead of `.git/**` and `.git/**/*` or `**/.git/**`)