### PR TITLE
Use babel-register on `src` (for dev) when `dist` isn't compiled

### DIFF
--- a/bin/sicksync.js
+++ b/bin/sicksync.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-require('../dist/index')();
+try {
+  require('../dist/index')();
+} catch (err) {
+  require('babel/register');
+  require('../src/index')();
+}


### PR DESCRIPTION
Ease development by not requiring to have `npm watch` running.
