### PR TITLE
feat: --no-delete

### DIFF
--- a/src/big-sync.js
+++ b/src/big-sync.js
@@ -27,8 +27,11 @@ export function bigSync(project) {
     .flags('az')
     .exclude(project.excludes)
     .source(ensureTrailingSlash(project.sourceLocation))
-    .set('delete')
     .destination(project.username + '@' + project.hostname + ':' + project.destinationLocation);
+
+  if (params.delete === true) {
+    rsync.set('delete')
+  }
 
   if (params.dry) {
     rsync.set('dry-run');

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -1,11 +1,13 @@
-import { ary, partial } from 'lodash';
+import _ from 'lodash';
 import { start } from '../local';
 
 function sicksyncStartCommand(program, config) {
   program
     .command('start [projects...]')
     .description('Starts the continuous sicksync process for the given project(s)')
-    .action(partial(ary(start, 2), config));
+    .option('-D, --no-delete', 'Do not delete remote files on inital rsync')
+    .action((projects, options) =>
+      start(_.extend(config, _.pick(options, ['delete'])), projects))
 }
 
 export default sicksyncStartCommand;

--- a/src/local/index.js
+++ b/src/local/index.js
@@ -80,7 +80,7 @@ function startProject(config, projectConf) {
 
     // WS events
   wsClient.on(wsEvents.READY, () => {
-    triggerBigSync(projectConf, { debug: config.debug }, () => {
+    triggerBigSync(projectConf, _.pick(config, ['debug', 'delete']), () => {
       fsHelper.watch();
 
       localLog(


### PR DESCRIPTION
Allow a --no-delete (alias: -D) option that prevents deleteing files on server on initial rsync.


fixes #69