### PR TITLE
fix: remove newline from execSync cygwin path

### DIFF
--- a/src/big-sync.js
+++ b/src/big-sync.js
@@ -19,7 +19,8 @@ export function bigSync(project) {
     _.noop;
 
   if (os.platform() === 'win32') {
-    project.sourceLocation = execSync('cygpath ' + project.sourceLocation).toString();
+    project.sourceLocation = execSync('cygpath ' + project.sourceLocation, { encoding: 'utf8' })
+      .replace(/[\n\r]/g, '');
   }
 
   const rsync = new Rsync()


### PR DESCRIPTION
fixes #70

Before:
```
project.sourceLocation = '/cygdrive/c/Users/x/test/sicksync-test/\n'
```
After:
```
project.sourceLocation = '/cygdrive/c/Users/x/test/sicksync-test/'
```